### PR TITLE
fix: Proper way to get high resolution millisecond timestamps

### DIFF
--- a/perf.js
+++ b/perf.js
@@ -1,4 +1,6 @@
-const start = Date.now();
+const { performance } = require("perf_hooks");
+
+const start = performance.now();
 const size = 65535;
 let answer = 0;
 
@@ -7,7 +9,7 @@ for(let i = 1; i <= size; i++) {
     if(i % j === 0) answer++;
   }
 }
-const diff = Date.now() - start;
+
+const diff = performance.now() - start;
 console.log(answer.toString());
 console.log(diff / 1000 + "s");
-


### PR DESCRIPTION
This is the proper way to get timestamps for performance calculations using Node. (perf_hooks is a native library)