### PR TITLE
Change benchmarking script for more advanced outputs

### DIFF
--- a/.github/workflows/results.yml
+++ b/.github/workflows/results.yml
@@ -27,18 +27,8 @@ jobs:
         with:
           python-version: pypy2
 
-      - name: Create new README
-        run: |
-          sed '/<!-- RESULTS -->/,$d' README.md > NEWREADME.md
-          echo -e '<!-- RESULTS -->\n```' >> NEWREADME.md
-
       - name: Run benchmarks
-        run: ./bench >> NEWREADME.md
-
-      - name: Replace old README
-        run: |
-          echo -e '```\n' >> NEWREADME.md
-          mv NEWREADME.md README.md
+        run: node bench.js
 
       - name: Commit new results
         uses: EndBug/add-and-commit@v7

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ and return the answer and time in seconds it took to calculate.
 
 ## Results
 
-Benchmark results of GitHub actions runner.
+Benchmark results of GitHub Actions runner. Smaller is better.
 
 <!-- RESULTS START -->
 <img src="https://quickchart.io/chart?c=%7B%22type%22%3A%22bar%22%2C%22data%22%3A%7B%22labels%22%3A%5B%22C%23%22%2C%22Node.js%22%2C%22Python%20(PyPy)%22%5D%2C%22datasets%22%3A%5B%7B%22label%22%3A%22Time%22%2C%22data%22%3A%5B11.52007%2C18.742006467000014%2C63.5191600323%5D%7D%5D%7D%7D" />

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ and return the answer and time in seconds it took to calculate.
 Benchmark results of GitHub actions runner.
 
 <!-- RESULTS START -->
-<img src="https://quickchart.io/chart?c=%7B%22type%22%3A%22bar%22%2C%22data%22%3A%7B%22labels%22%3A%5B%22C%23%22%2C%22Node.js%22%2C%22Python%20(Py)%22%5D%2C%22datasets%22%3A%5B%7B%22label%22%3A%22Time%22%2C%22data%22%3A%5B0.000723%2C0.00423360002040863%2C0.01901388168334961%5D%7D%5D%7D%7D" />
+<img src="https://quickchart.io/chart?c=%7B%22type%22%3A%22bar%22%2C%22data%22%3A%7B%22labels%22%3A%5B%22C%23%22%2C%22Node.js%22%2C%22Python%20(PyPy)%22%5D%2C%22datasets%22%3A%5B%7B%22label%22%3A%22Time%22%2C%22data%22%3A%5B11.52007%2C18.742006467000014%2C63.5191600323%5D%7D%5D%7D%7D" />
 
 |Name|Time|
 |---|---|
-|C#|0.000723s|
-|Node.js|0.00423360002040863s|
-|Python (Py)|0.01901388168334961s|
+|C#|11.520070s|
+|Node.js|18.742006467000014s|
+|Python (PyPy)|63.5191600323s|
 
 <!-- RESULTS END -->
 

--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ and return the answer and time in seconds it took to calculate.
 Benchmark results of GitHub Actions runner. Smaller is better.
 
 <!-- RESULTS START -->
-<img src="https://quickchart.io/chart?backgroundColor=white&c=%7B%22type%22%3A%22bar%22%2C%22data%22%3A%7B%22labels%22%3A%5B%22C%23%22%2C%22Node.js%22%2C%22Python%20(PyPy)%22%2C%22Lua%20(LuaJIT)%22%2C%22Rust%22%2C%22Go%22%2C%22C%20(GCC)%22%2C%22C%2B%2B%20(G%2B%2B)%22%2C%22Java%22%5D%2C%22datasets%22%3A%5B%7B%22label%22%3A%22Time%22%2C%22data%22%3A%5B11.512607%2C18.727338117999984%2C56.4145078659%2C6.938127%2C11.512%2C40.967403904%2C11.498816%2C10.160059%2C17.18%5D%7D%5D%7D%7D" />
+<img src="https://quickchart.io/chart?backgroundColor=white&c=%7B%22type%22%3A%22bar%22%2C%22data%22%3A%7B%22labels%22%3A%5B%22Lua%20(LuaJIT)%22%2C%22C%20(GCC)%22%2C%22Rust%22%2C%22C%23%22%2C%22C%2B%2B%20(G%2B%2B)%22%2C%22Java%22%2C%22Node.js%22%2C%22Go%22%2C%22Python%20(PyPy)%22%5D%2C%22datasets%22%3A%5B%7B%22label%22%3A%22Time%22%2C%22data%22%3A%5B9.427376%2C13.796384%2C13.809%2C13.817747%2C13.838977%2C20.563%2C22.459493671000004%2C49.218947721%2C76.6994969845%5D%7D%5D%7D%7D" />
 
-|Name|Time|
-|---|---|
-|Lua (LuaJIT)|6.938127s|
-|C++ (G++)|10.160059s|
-|C (GCC)|11.498816s|
-|Rust|11.512s|
-|C#|11.512607s|
-|Java|17.18s|
-|Node.js|18.727338117999984s|
-|Go|40.967403904s|
-|Python (PyPy)|56.4145078659s|
+|Name|Time|Iterations|
+|---|---|---|
+|Lua (LuaJIT)|9.427376s|736957|
+|C (GCC)|13.796384s|736957|
+|Rust|13.809s|736957|
+|C#|13.817747s|736957|
+|C++ (G++)|13.838977s|736957|
+|Java|20.563s|736957|
+|Node.js|22.459493671000004s|736957|
+|Go|49.218947721s|736957|
+|Python (PyPy)|76.6994969845s|736957|
 
 <!-- RESULTS END -->
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,21 @@ for (a = 1; a <= 65535; a++) {
 
 and return the answer and time in seconds it took to calculate.
 
+## Results
+
+Benchmark results of GitHub actions runner.
+
+<!-- RESULTS START -->
+<img src="https://quickchart.io/chart?c=%7B%22type%22%3A%22bar%22%2C%22data%22%3A%7B%22labels%22%3A%5B%22C%23%22%2C%22Node.js%22%2C%22Python%20(Py)%22%5D%2C%22datasets%22%3A%5B%7B%22label%22%3A%22Time%22%2C%22data%22%3A%5B0.000723%2C0.00423360002040863%2C0.01901388168334961%5D%7D%5D%7D%7D" />
+
+|Name|Time|
+|---|---|
+|C#|0.000723s|
+|Node.js|0.00423360002040863s|
+|Python (Py)|0.01901388168334961s|
+
+<!-- RESULTS END -->
+
 ## Dependencies
 
 - [Java JDK](https://adoptopenjdk.net/)
@@ -31,50 +46,3 @@ Each program needs to be added to PATH if the associated installer or package do
 ## Running
 
 Simply run the `bench` script (`bench.bat` on Windows) and wait for all the results. You may notice some new files as languages like C, C++, C#, Java, and Rust need to be compiled and leave build artefacts. If there is an error, ensure that the program that errored is installed and on the PATH environment variable. If it is and it keeps erroring or crashing, then open an issue.
-
-## Results
-
-Benchmark results of GitHub actions runner.
-
-<!-- RESULTS -->
-```
-Very cool language benchmark script
----
-Node.js
-736957
-18.527391325999996s
----
-Lua (LuaJIT)
-736957
-7.069992s
----
-Rust
-736957
-14.516s
----
-Go
-736957
-38.218117858s
----
-Python (PyPy)
-736957
-61.3658149242s
----
-C (GCC)
-736957
-12.372645s
----
-C++ (G++)
-736957
-15.182596s
----
-C#
-736957
-15.134069s
----
-Java
-736957
-22.17s
----
-```
-

--- a/README.md
+++ b/README.md
@@ -18,13 +18,19 @@ and return the answer and time in seconds it took to calculate.
 Benchmark results of GitHub actions runner.
 
 <!-- RESULTS START -->
-<img src="https://quickchart.io/chart?c=%7B%22type%22%3A%22bar%22%2C%22data%22%3A%7B%22labels%22%3A%5B%22C%23%22%2C%22Node.js%22%2C%22Python%20(PyPy)%22%5D%2C%22datasets%22%3A%5B%7B%22label%22%3A%22Time%22%2C%22data%22%3A%5B11.52007%2C18.742006467000014%2C63.5191600323%5D%7D%5D%7D%7D" />
+<img src="https://quickchart.io/chart?backgroundColor=white&c=%7B%22type%22%3A%22bar%22%2C%22data%22%3A%7B%22labels%22%3A%5B%22C%23%22%2C%22Node.js%22%2C%22Python%20(PyPy)%22%2C%22Lua%20(LuaJIT)%22%2C%22Rust%22%2C%22Go%22%2C%22C%20(GCC)%22%2C%22C%2B%2B%20(G%2B%2B)%22%2C%22Java%22%5D%2C%22datasets%22%3A%5B%7B%22label%22%3A%22Time%22%2C%22data%22%3A%5B11.512607%2C18.727338117999984%2C56.4145078659%2C6.938127%2C11.512%2C40.967403904%2C11.498816%2C10.160059%2C17.18%5D%7D%5D%7D%7D" />
 
 |Name|Time|
 |---|---|
-|C#|11.520070s|
-|Node.js|18.742006467000014s|
-|Python (PyPy)|63.5191600323s|
+|Lua (LuaJIT)|6.938127s|
+|C++ (G++)|10.160059s|
+|C (GCC)|11.498816s|
+|Rust|11.512s|
+|C#|11.512607s|
+|Java|17.18s|
+|Node.js|18.727338117999984s|
+|Go|40.967403904s|
+|Python (PyPy)|56.4145078659s|
 
 <!-- RESULTS END -->
 

--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ and return the answer and time in seconds it took to calculate.
 Benchmark results of GitHub Actions runner. Smaller is better.
 
 <!-- RESULTS START -->
-<img src="https://quickchart.io/chart?backgroundColor=white&c=%7B%22type%22%3A%22bar%22%2C%22data%22%3A%7B%22labels%22%3A%5B%22Lua%20(LuaJIT)%22%2C%22C%20(GCC)%22%2C%22Rust%22%2C%22C%23%22%2C%22C%2B%2B%20(G%2B%2B)%22%2C%22Java%22%2C%22Node.js%22%2C%22Go%22%2C%22Python%20(PyPy)%22%5D%2C%22datasets%22%3A%5B%7B%22label%22%3A%22Time%22%2C%22data%22%3A%5B9.427376%2C13.796384%2C13.809%2C13.817747%2C13.838977%2C20.563%2C22.459493671000004%2C49.218947721%2C76.6994969845%5D%7D%5D%7D%7D" />
+<img src="https://quickchart.io/chart?backgroundColor=white&c=%7B%22type%22%3A%22bar%22%2C%22data%22%3A%7B%22labels%22%3A%5B%22Lua%20(LuaJIT)%22%2C%22C%20(GCC)%22%2C%22Rust%22%2C%22C%2B%2B%20(G%2B%2B)%22%2C%22C%23%22%2C%22Java%22%2C%22Node.js%22%2C%22Go%22%2C%22Python%20(PyPy)%22%5D%2C%22datasets%22%3A%5B%7B%22label%22%3A%22Time%22%2C%22data%22%3A%5B9.446317%2C13.800214%2C13.808%2C13.820863%2C13.852567%2C20.608%2C22.45517606%2C49.192992355%2C76.6553580761%5D%7D%5D%7D%7D" />
 
-|Name|Time|Iterations|
-|---|---|---|
-|Lua (LuaJIT)|9.427376s|736957|
-|C (GCC)|13.796384s|736957|
-|Rust|13.809s|736957|
-|C#|13.817747s|736957|
-|C++ (G++)|13.838977s|736957|
-|Java|20.563s|736957|
-|Node.js|22.459493671000004s|736957|
-|Go|49.218947721s|736957|
-|Python (PyPy)|76.6994969845s|736957|
+|#|Name|Time|Answer|
+|---|---|---|---|
+|1|Lua (LuaJIT)|9.446317s|736957|
+|2|C (GCC)|13.800214s|736957|
+|3|Rust|13.808s|736957|
+|4|C++ (G++)|13.820863s|736957|
+|5|C#|13.852567s|736957|
+|6|Java|20.608s|736957|
+|7|Node.js|22.45517606s|736957|
+|8|Go|49.192992355s|736957|
+|9|Python (PyPy)|76.6553580761s|736957|
 
 <!-- RESULTS END -->
 

--- a/bench.js
+++ b/bench.js
@@ -74,7 +74,7 @@ const generateChartUrl = (benchmarks) => {
 };
 
 const generateMarkdownTable = (benchmarks) => {
-    const header = `|#|Name|Time|Iterations|\n|---|---|---|---|\n`;
+    const header = `|#|Name|Time|Answer|\n|---|---|---|---|\n`;
     const content = benchmarks.map((benchmark, index) => `|${index + 1}|${benchmark.name}|${benchmark.time}|${benchmark.size}|\n`).join("");
     return header + content;
 };

--- a/bench.js
+++ b/bench.js
@@ -1,0 +1,75 @@
+const process = require("child_process");
+const fs = require("fs/promises");
+
+const benchmarks = [
+    {
+        name: "C#",
+        perf: "dotnet run --configuration Release --verbosity quiet",
+        cwd: "./perfcsharpsrc/"
+    },
+    {
+        name: "Node.js",
+        perf: "node perf.js"
+    },
+    {
+        name: "Python (Py)",
+        perf: "py perf.py"
+    }
+];
+
+const run = (perf, cwd = ".") => new Promise((resolve, reject) => {
+    const arguments = perf.split(" ");
+    const perfProcess = process.spawn(arguments.shift(), arguments, {cwd});
+
+    let data = "";
+    perfProcess.stdout.on("data", (output) => data += output.toString());
+    perfProcess.on("close", () => {
+        resolve(data)
+    });
+});
+
+const timeToFloat = time => parseFloat(time.slice(0, -1));
+
+const generateChartUrl = (benchmarks) => {
+    const data = {
+        type: "bar",
+        data: {
+            labels: benchmarks.map(b => b.name),
+            datasets: [{
+                label: "Time",
+                data: benchmarks.map(b => timeToFloat(b.time))
+            }]
+        }
+    };
+    return `https://quickchart.io/chart?c=${encodeURIComponent(JSON.stringify(data))}`;
+};
+
+const generateMarkdownTable = (benchmarks) => {
+    const header = `|Name|Time|\n|---|---|\n`;
+    benchmarks.sort((a, b) => (timeToFloat(a.time) - timeToFloat(b.time)))
+    const content = benchmarks.map(benchmark => `|${benchmark.name}|${benchmark.time}|\n`).join("");
+    return header + content;
+};
+
+(async () => {
+    for await (const benchmark of benchmarks) {
+        const results = await run(benchmark.perf, benchmark.cwd)
+        const [size, time] = results.split("\n").map(i => i.trim());
+        benchmark.size = size;
+        benchmark.time = time;
+    }
+
+    console.log(benchmarks);
+
+    const chartUrl = generateChartUrl(benchmarks);
+    const table = generateMarkdownTable(benchmarks);
+
+    const content = `<img src="${chartUrl}" />\n\n${table}`;
+
+    let readme = await fs.readFile("README.md", "utf8");
+
+    // Be sure that README.md uses LF line endings
+    readme = readme.replace(/(.*<!-- RESULTS START -->\n)(.*)(\n<!-- RESULTS END -->.*)/s, `$1${content}$3`);
+
+    await fs.writeFile("README.md", readme);
+})();

--- a/bench.js
+++ b/bench.js
@@ -74,9 +74,9 @@ const generateChartUrl = (benchmarks) => {
 };
 
 const generateMarkdownTable = (benchmarks) => {
-    const header = `|Name|Time|\n|---|---|\n`;
+    const header = `|Name|Time|Iterations|\n|---|---|---|\n`;
     benchmarks.sort((a, b) => (timeToFloat(a.time) - timeToFloat(b.time)))
-    const content = benchmarks.map(benchmark => `|${benchmark.name}|${benchmark.time}|\n`).join("");
+    const content = benchmarks.map(benchmark => `|${benchmark.name}|${benchmark.time}|${benchmark.size}|\n`).join("");
     return header + content;
 };
 

--- a/bench.js
+++ b/bench.js
@@ -12,8 +12,8 @@ const benchmarks = [
         perf: "node perf.js"
     },
     {
-        name: "Python (Py)",
-        perf: "py perf.py"
+        name: "Python (PyPy)",
+        perf: "pypy3 perf.py"
     }
 ];
 

--- a/bench.js
+++ b/bench.js
@@ -13,7 +13,7 @@ const benchmarks = [
     },
     {
         name: "Python (PyPy)",
-        perf: "pypy3 perf.py"
+        perf: "pypy perf.py"
     }
 ];
 
@@ -24,6 +24,7 @@ const run = (perf, cwd = ".") => new Promise((resolve, reject) => {
     let data = "";
     perfProcess.stdout.on("data", (output) => data += output.toString());
     perfProcess.on("close", () => {
+        console.log(`${perf}\n${data.split('\n').map(d => `    ${d}`).join('\n')}`);
         resolve(data)
     });
 });

--- a/bench.js
+++ b/bench.js
@@ -30,15 +30,18 @@ const benchmarks = [
     },
     {
         name: "C (GCC)",
-        perf: "gcc perf.c -Ofast -o perfc && ./perfc"
+        build: "gcc perf.c -Ofast -o perfc",
+        perf: "./perfc"
     },
     {
         name: "C++ (G++)",
-        perf: "g++ perf.cpp -Ofast -o perfcpp && ./perfcpp"
+        build: "g++ perf.cpp -Ofast -o perfcpp",
+        perf: "./perfcpp"
     },
     {
         name: "Java",
-        perf: "javac perf.java && java perf"
+        build: "javac perf.java",
+        perf: "java perf"
     }
 ];
 
@@ -67,7 +70,7 @@ const generateChartUrl = (benchmarks) => {
             }]
         }
     };
-    return `https://quickchart.io/chart?c=${encodeURIComponent(JSON.stringify(data))}`;
+    return `https://quickchart.io/chart?backgroundColor=white&c=${encodeURIComponent(JSON.stringify(data))}`;
 };
 
 const generateMarkdownTable = (benchmarks) => {
@@ -79,7 +82,8 @@ const generateMarkdownTable = (benchmarks) => {
 
 (async () => {
     for await (const benchmark of benchmarks) {
-        const results = await run(benchmark.perf, benchmark.cwd)
+        if (benchmark.build) await run(benchmark.build);
+        const results = await run(benchmark.perf, benchmark.cwd);
         const [size, time] = results.split("\n").map(i => i.trim());
         benchmark.size = size;
         benchmark.time = time;

--- a/bench.js
+++ b/bench.js
@@ -75,7 +75,6 @@ const generateChartUrl = (benchmarks) => {
 
 const generateMarkdownTable = (benchmarks) => {
     const header = `|Name|Time|Iterations|\n|---|---|---|\n`;
-    benchmarks.sort((a, b) => (timeToFloat(a.time) - timeToFloat(b.time)))
     const content = benchmarks.map(benchmark => `|${benchmark.name}|${benchmark.time}|${benchmark.size}|\n`).join("");
     return header + content;
 };
@@ -88,6 +87,7 @@ const generateMarkdownTable = (benchmarks) => {
         benchmark.size = size;
         benchmark.time = time;
     }
+    benchmarks.sort((a, b) => (timeToFloat(a.time) - timeToFloat(b.time)));
 
     console.log(benchmarks);
 

--- a/bench.js
+++ b/bench.js
@@ -74,8 +74,8 @@ const generateChartUrl = (benchmarks) => {
 };
 
 const generateMarkdownTable = (benchmarks) => {
-    const header = `|Name|Time|Iterations|\n|---|---|---|\n`;
-    const content = benchmarks.map(benchmark => `|${benchmark.name}|${benchmark.time}|${benchmark.size}|\n`).join("");
+    const header = `|#|Name|Time|Iterations|\n|---|---|---|---|\n`;
+    const content = benchmarks.map((benchmark, index) => `|${index + 1}|${benchmark.name}|${benchmark.time}|${benchmark.size}|\n`).join("");
     return header + content;
 };
 

--- a/bench.js
+++ b/bench.js
@@ -14,6 +14,31 @@ const benchmarks = [
     {
         name: "Python (PyPy)",
         perf: "pypy perf.py"
+    },
+    {
+        name: "Lua (LuaJIT)",
+        perf: "luajit perf.lua"
+    },
+    {
+        name: "Rust",
+        perf: "cargo run -q --release",
+        cwd: "./perfrustsrc/"
+    },
+    {
+        name: "Go",
+        perf: "go run perf.go"
+    },
+    {
+        name: "C (GCC)",
+        perf: "gcc perf.c -Ofast -o perfc && ./perfc"
+    },
+    {
+        name: "C++ (G++)",
+        perf: "g++ perf.cpp -Ofast -o perfcpp && ./perfcpp"
+    },
+    {
+        name: "Java",
+        perf: "javac perf.java && java perf"
     }
 ];
 


### PR DESCRIPTION
Outputs the benchmarks as a beautiful bar graph and table, sorted by time.

<details>
<summary>Old output</summary>
<img src="https://user-images.githubusercontent.com/46541386/129071450-cf0f255f-d18d-4af5-8bb7-f42f5369bba0.png">
</details>
<details>
<summary>New output</summary>
<img src="https://user-images.githubusercontent.com/46541386/129071420-f16048e6-adee-4a38-8f74-a849b9c29c62.png">
</details>

You can use squash merge, there's so many trial and error commits.